### PR TITLE
don't overwrite AndroidManifest.xml and configAndroid.json

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Set version
 set(ANDROID_VERSION_NAME ${DEMO_VERSION})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AndroidManifest.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AndroidManifest.xml.cmake ${CMAKE_CURRENT_SOURCE_DIR}/AndroidManifest.xml @ONLY)
 
 
 # Androiddeployqt configuration
@@ -23,13 +23,12 @@ find_program(QT_QMAKE_EXECUTABLE NAMES qmake)
 
 # Create json file parsed by the androiddeployqt
 set(ANDROID_SDK $ENV{ANDROID_SDK})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configAndroid.json.cmake ${CMAKE_CURRENT_BINARY_DIR}/configAndroid.json @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configAndroid.json.cmake ${CMAKE_CURRENT_SOURCE_DIR}/configAndroid.json @ONLY)
 
 add_custom_command (
   OUTPUT createApkFromAndroidDeployQt
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
-  COMMAND androiddeployqt --verbose --output ${CMAKE_CURRENT_BINARY_DIR}/ --input ${CMAKE_CURRENT_BINARY_DIR}/configAndroid.json
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/AndroidManifest.xml
+  COMMAND androiddeployqt --verbose --output ${CMAKE_CURRENT_BINARY_DIR}/ --input ${CMAKE_CURRENT_SOURCE_DIR}/configAndroid.json
 )
 
 # Command to create debug apk from Makefile

--- a/android/configAndroid.json.cmake
+++ b/android/configAndroid.json.cmake
@@ -9,5 +9,6 @@
  "ndk-host": "@ANDROID_NDK_HOST_SYSTEM_NAME@",
  "target-architecture": "@ARM_TARGET@",
  "application-binary": "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@libDemo.so",
+ "android-package-source-directory": "@CMAKE_CURRENT_SOURCE_DIR@",
  "android-package": "net.demo"
 }


### PR DESCRIPTION
Don't create the generated configured files (AndroidManifest.xml and
configAndroid.json) in the binary directory because androiddeployqt will
overwrite them with the default ones.

We now generate AndroidManifest.xml and configAndroid.json in the source
directory and make "android-package-source-directory" point to
"@CMAKE_CURRENT_SOURCE_DIR@", this will avoid copying a bunch of files
as well.
